### PR TITLE
Fix: disappearing star on mobile

### DIFF
--- a/background.js
+++ b/background.js
@@ -98,7 +98,7 @@ async function copyToClipboard({ urgency, size }, { onMessage }) {
                         : ':empty_star:';
                     }
                   })
-                  .join('');
+                  .join('\u200a');
               };
 
               const decorateSizeAndUrgency = () => {


### PR DESCRIPTION
Added invisible character to fix issue on mobile Slack iOS

On mobile:
![IMG_1305](https://user-images.githubusercontent.com/12198761/170096694-417057d7-2d40-4f53-9182-6cde76897a8e.jpg)


On desktop:
<img width="275" alt="image" src="https://user-images.githubusercontent.com/12198761/170096534-1ccdcfb9-6d21-4cff-8606-3c0c37a135ba.png">
