### PR TITLE
feat: parse requested reviewers

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/popup.css
+++ b/popup.css
@@ -40,7 +40,7 @@ label {
 }
 
 #autodetect {
-  color: #ccc;
+  color: #999;
   display: none;
   font-size: x-small;
   margin-left: 1ex;
@@ -64,4 +64,45 @@ label {
 
 .star-path--half {
   fill: url('#halfFullGradient');
+}
+
+.reviewer-container {
+  display: none;
+}
+.reviewer-container ul{
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.reviewer-container label {
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  margin: 0;
+}
+.reviewer-container input[type=checkbox] {
+  margin-inline-end: 1ex;
+}
+.link-button {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  text-decoration: underline;
+  cursor: pointer;
+}
+.link-button:hover {
+  text-decoration: none;
+}
+
+.note {
+  color: #555;
+  font-size: x-small;
+  margin-top: 1em;
+  display: none;
+}
+
+.visible {
+  display: initial;
 }

--- a/popup.html
+++ b/popup.html
@@ -16,7 +16,13 @@
       <div class="star-container js-urgency-stars"></div>
       <input type="range" id="urgency" name="urgency" min="1" max="6" value="2">
 
+      
+      <div class="reviewer-container js-reviewers">
+        <div>CC reviewers: (<button class="btn-reviewers-none link-button">none</button>)</div>
+      </div>
+
       <button class="btn-submit" type="submit"></button>
+      <div class="note js-note">press <strong>tab</strong> after pasting in slack to mention-ify the usernames</div>
     </form>
     <svg id="star-gradient-defs" width="0" height="0" viewBox="0 0 0 0">
       <title>Star fill gradients</title>


### PR DESCRIPTION
## Why?
Sometimes you want to direct attention to a single reviewer. The esteemed code review tool has suboptimal native notifications. Often, I've found myself manually adding @-mentions after I paste the formatted text from this extension.

## What?
This PR:
- modifies the main function that runs in the code review window to scrape requested reviewers from the html and the bootstrapped json data used to render tooltips. From this, we get the reviewers username and the status of the review (requested, approved, etc). We just want the ones with status = requested.
  - Also: Minor refactoring to the code in `background.js` to accomodate more generalized data flow between the main window and the popup window.
  - Text decoration for the selected reviewers
- If pending reviewers are detected, show a checkbox list in the popup window to select them, with a link button to deselect all. When you click "copy", it sends the selected reviewers, if any, along with the rest of the data back to be copied to clipboard.
- Lastly, I add a .prettierrc to keep my editor from trying to reformat all the quotes :) I can remove this if you'd rather not include config files in the repo.